### PR TITLE
Fix nearMatchPercent misspelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alugha/ima",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A library for asynchronously loading the Google IMA SDK with static typing for the SDK",
   "license": "MIT",
   "author": "Niklas Korz <nk@alugha.com>",

--- a/src/ima.d.ts
+++ b/src/ima.d.ts
@@ -1042,7 +1042,7 @@ export namespace google {
       /**
        * The near fit percent set by the user.
        */
-      public nearMatchParent: number;
+      public nearMatchPercent: number;
       /**
        * Resource type setting set by the user.
        */


### PR DESCRIPTION
Fix misspelling on nearMatchPercent in order to match Google IMA SDK docs

Closes #9 