### PR TITLE
don't load from protocol-relative url

### DIFF
--- a/src/loadImaSdk.ts
+++ b/src/loadImaSdk.ts
@@ -7,7 +7,8 @@ interface ImaWindow {
   };
 }
 
-const imaSdkSrc = "//imasdk.googleapis.com/js/sdkloader/ima3.js";
+const imaSdkProtocol = location.protocol === "http:" ? "http:" : "https:";
+const imaSdkSrc = imaSdkProtocol + "//imasdk.googleapis.com/js/sdkloader/ima3.js";
 let pendingPromise: Promise<typeof google.ima> | null = null;
 
 const promiseFinished = () => {


### PR DESCRIPTION
Rather than using a protocol-relative url, use `https://` unless current page is `http://` Realistically, should probably just always load from `https://`, but to keep in line with the current behavior, I made it fall back to `http://`

The reason being, capacitor-based mobile apps use the `capacitor://` protocol in a web view on iOS. The protocol relative URL tries to load `capacitor://imasdk.googleapis.com/js/sdkloader/ima3.js` which is not valid.