### PR TITLE
just force https

### DIFF
--- a/src/loadImaSdk.ts
+++ b/src/loadImaSdk.ts
@@ -7,8 +7,7 @@ interface ImaWindow {
   };
 }
 
-const imaSdkProtocol = location.protocol === "http:" ? "http:" : "https:";
-const imaSdkSrc = imaSdkProtocol + "//imasdk.googleapis.com/js/sdkloader/ima3.js";
+const imaSdkSrc = "https://imasdk.googleapis.com/js/sdkloader/ima3.js";
 let pendingPromise: Promise<typeof google.ima> | null = null;
 
 const promiseFinished = () => {


### PR DESCRIPTION
I ran into trouble with loading the ima sdk on Capacitor again, Android this time. Capacitor on Android uses a http://localhost origin but also blocks any non-https requests to the internet. figured it safe enough to just always load the https version. 